### PR TITLE
Add arrow keys for traversing guess history

### DIFF
--- a/DEVELOPER_README.md
+++ b/DEVELOPER_README.md
@@ -1,0 +1,8 @@
+## Local development
+
+1. Run server: `go run .`
+1. SSH in: `ssh localhost`
+
+If you get blocked from ssh-ing into localhost in future attempts, remove your old host key:
+
+`ssh-keygen -R localhost`

--- a/play.go
+++ b/play.go
@@ -70,6 +70,7 @@ func (m Play) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case tea.KeyEnter:
 			move := m.Input.Value()
+			m.movePos = -1 // reset movePos
 
 			if len(move) != 6 {
 				m.state.gameState = Invalid

--- a/play.go
+++ b/play.go
@@ -56,6 +56,8 @@ func (m Play) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
                     m.Input.SetValue(moves[len(moves)-1-m.movePos])
                 }
             }
+			return m, nil  // Return early to prevent viewport processing
+
 
 		// Down key: move forward in guess history, if already viewing history
         case tea.KeyDown:
@@ -67,6 +69,8 @@ func (m Play) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
                 m.movePos = -1
                 m.Input.SetValue("")
             }
+			return m, nil  // Return early to prevent viewport processing
+
 
 		case tea.KeyEnter:
 			move := m.Input.Value()

--- a/play.go
+++ b/play.go
@@ -15,6 +15,7 @@ type Play struct {
 	state    *state
 	Input    textinput.Model
 	Viewport viewport.Model
+	movePos int
 }
 
 func (m Play) New() Play {
@@ -28,6 +29,7 @@ func (m Play) New() Play {
 	m.Viewport = viewport.New(12, m.state.height-10)
 	m.Viewport.SetContent(lipgloss.JoinVertical(0, m.displayMoves()...))
 	m.state.gameState = Idle
+	m.movePos = -1 // initialize move (guess) history at -1
 	return m
 }
 
@@ -44,6 +46,27 @@ func (m Play) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.Type {
+
+		// Up key: get previous move(s) in guess history
+		case tea.KeyUp:
+            moves := m.state.GetMoves()
+            if len(moves) > 0 {
+                if m.movePos < len(moves)-1 {
+                    m.movePos++
+                    m.Input.SetValue(moves[len(moves)-1-m.movePos])
+                }
+            }
+
+		// Down key: move forward in guess history, if already viewing history
+        case tea.KeyDown:
+             if m.movePos > 0 {
+                m.movePos--
+                moves := m.state.GetMoves()
+                m.Input.SetValue(moves[len(moves)-1-m.movePos])
+            } else if m.movePos == 0 {
+                m.movePos = -1
+                m.Input.SetValue("")
+            }
 
 		case tea.KeyEnter:
 			move := m.Input.Value()


### PR DESCRIPTION
- Adds ability to fetch past guesses with arrow keys up/down, for frictionless next guesses 
- Adds dev readme 

![foo](https://github.com/user-attachments/assets/0e89da73-1a67-4581-89d8-41d114897f10)
