### PR TITLE
fix: allocate a TTY so that cursor mode settings propagate across SSH

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   app:
+    tty: true
+    ports:
+      - "22:22"
     build: .
     volumes:
       - ./store:/usr/src/app/store
-    network_mode: "host"


### PR DESCRIPTION
With @jmontroy90, we discovered that `docker run -t` resolves the issue where the game correctly displays the cursor locally but not in the container. This changes the docker-compose file to allocate a TTY. Instead of using the host network (which @jmontroy90 suggests is unsafe), we also expose container port 22 as host port 22 with the `ports` line. Fixes #5.